### PR TITLE
Editorial: simplify early errors

### DIFF
--- a/spec/sec-identifiers-static-semantics-early-errors-patch.html
+++ b/spec/sec-identifiers-static-semantics-early-errors-patch.html
@@ -6,19 +6,19 @@
       It is a Syntax Error if the code matched by this production is contained in strict mode code and the StringValue of |Identifier| is *"arguments"* or *"eval"*.
     </li>
     <li>
-      <ins>It is a Syntax Error if the code matched by this production is nested, directly or indirectly (but not crossing function or `static` initialization block boundaries), within a |ClassStaticBlock| and the StringValue of |Identifier| is *"await"*.</ins>
+      <ins>It is a Syntax Error if the code matched by this production is nested, directly or indirectly (but not crossing function boundaries), within a |ClassStaticBlock| and the StringValue of |Identifier| is *"await"*.</ins>
     </li>
   </ul>
   <emu-grammar><ins>LabelIdentifier : Identifier</ins></emu-grammar>
   <ul>
     <li>
-      <ins>It is a Syntax Error if the code matched by this production is nested, directly or indirectly (but not crossing function or `static` initialization block boundaries), within a |ClassStaticBlock| and the StringValue of |Identifier| is *"await"*.</ins>
+      <ins>It is a Syntax Error if the code matched by this production is nested, directly or indirectly (but not crossing function boundaries), within a |ClassStaticBlock| and the StringValue of |Identifier| is *"await"*.</ins>
     </li>
   </ul>
   <emu-grammar><ins>IdentifierReference : Identifier</ins></emu-grammar>
   <ul>
     <li>
-      <ins>It is a Syntax Error if the code matched by this production is nested, directly or indirectly (but not crossing function or `static` initialization block boundaries), within a |ClassStaticBlock| and the StringValue of |Identifier| is *"arguments"* or *"await"*.</ins>
+      <ins>It is a Syntax Error if the code matched by this production is nested, directly or indirectly (but not crossing function boundaries), within a |ClassStaticBlock| and the StringValue of |Identifier| is *"arguments"* or *"await"*.</ins>
     </li>
   </ul>
 </emu-clause>


### PR DESCRIPTION
Prior to this commit, the early errors for
ClassStaticInitializationBlock were not applied when nesting crossed
"function or `static` initialization block boundaries." In the latter
case (that is: nesting within a "static" initialization block), the rule
applies recursively, triggering the early error despite the exception.

Remove the exception to simplify the rule's definition.